### PR TITLE
Set Access-Control-Allow-Origin: *

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -29,7 +29,21 @@ const HapiStaticFiles = {
       },
       config: {
         description: 'Static files of the application',
-        cors: true,
+        ext: {
+          onPostHandler: {
+            method(request, reply) {
+              // We check this as some error response do not have a `header` method
+              // We can remove this once error management is improved in the application
+              if (request.response && typeof request.response.header === 'function') {
+                request.response.header('Access-Control-Allow-Origin', '*');
+                request.response.header('Access-Control-Allow-Headers',
+                  'Origin, X-Requested-With, Accept, Content-Type, If-None-Match');
+                request.response.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+              }
+              reply.continue();
+            }
+          }
+        },
         cache: {
           expiresIn: ms('1y')
         },

--- a/es/index.js
+++ b/es/index.js
@@ -32,9 +32,11 @@ const HapiStaticFiles = {
         ext: {
           onPostHandler: {
             method(request, reply) {
-              // We check this as some error response do not have a `header` method
+              // Check this as some error response do not have a `header` method
               // We can remove this once error management is improved in the application
               if (request.response && typeof request.response.header === 'function') {
+                // Manually set the headers because Hapi uses the Origin request header instead of
+                // the wildcard value (and sets Vary: Origin) and breaks caches
                 request.response.header('Access-Control-Allow-Origin', '*');
                 request.response.header('Access-Control-Allow-Headers',
                   'Origin, X-Requested-With, Accept, Content-Type, If-None-Match');


### PR DESCRIPTION
Hapi sets "Access-Control-Allow-Origin: <Origin request header>" and "Vary: Origin" so it breaks caches unnecessarily. This change sets the CORS headers manually to avoid that.